### PR TITLE
Removing old "userid" entry of "instagram_json"

### DIFF
--- a/core/components/socialhub/model/socialhub/socialhub.class.php
+++ b/core/components/socialhub/model/socialhub/socialhub.class.php
@@ -291,6 +291,8 @@ class SocialHub
 
                     if (!isset($response['code']) && isset($response['access_token'])) {
                         $user = $response['user']['id'];
+                        $clients[$user] = $clients[trim($key)];
+                        unset($clients[trim($key)]);
                         $clients[$user]['token'] = $response['access_token'];
                         $clients[$user]['code'] = '';
                     }


### PR DESCRIPTION
If you start with a json entry like: `{"userid":{"username":"__username__"}}`
After the cronjob socialHub will create the instagramm access token and will store this data with a new json entry.
Like that: `{"userid":{"username":"__username__"},"12345678":{"token":"123456789012345"}}`
The initial setup entry with "userid" will still be there and will cause errors in the cron. I would suggest to remove this entry.